### PR TITLE
handle no-key in account parsing

### DIFF
--- a/src/pysiaalarm/errors.py
+++ b/src/pysiaalarm/errors.py
@@ -35,3 +35,8 @@ class EventCRCError(Exception):
     """Error for when a event hass a mismatched CRC."""
 
     pass
+
+class NoAccountError(Exception):
+    """Error for when a account is not present."""
+
+    pass

--- a/src/pysiaalarm/event.py
+++ b/src/pysiaalarm/event.py
@@ -13,7 +13,7 @@ from Crypto.Cipher._mode_cbc import CbcMode
 
 from .account import SIAAccount
 from .const import IV, RSP_XDATA
-from .errors import EventFormatError
+from .errors import EventFormatError, NoAccountError
 from .utils import (
     MAIN_MATCHER,
     OH_MATCHER,
@@ -215,13 +215,11 @@ class SIAEvent(BaseEvent):
         if not self.calc_crc:
             self.calc_crc = self._crc_calc(self.full_message)
         # If there is encrypted content and a key, decrypt
-        if (
-            self.sia_account
-            and self.sia_account.encrypted
-            and self.encrypted_content
-            and not self._encrypted_content_decrypted
-        ):
-            self.decrypt_content()
+        if self.encrypted_content:
+            if not self.sia_account or not self.sia_account.encrypted:
+                raise NoAccountError("No account present with encrypted message.")
+            if not self._encrypted_content_decrypted:
+                self.decrypt_content()
         # If there is content (either after decrypting or directly) parse
         if self.content and not self._content_parsed:
             self.parse_content()

--- a/tests/test_sia_package_cases.py
+++ b/tests/test_sia_package_cases.py
@@ -110,7 +110,7 @@ def fault_timestamp():
 class EventParsing:
     """Test cases for event parsing.
 
-    Emits these fields: "line, account_id, type, code, error, extended_data_flag"
+    Emits these fields: "line, account_id, code_type, code, error, extended_data_flag, encrypted_flag"
 
     """
 
@@ -123,6 +123,7 @@ class EventParsing:
             "CL",
             None,
             False,
+            False,
         )
 
     def case_bug2(self):
@@ -133,6 +134,7 @@ class EventParsing:
             "Heat Restoral",
             "KR",
             None,
+            False,
             False,
         )
 
@@ -145,6 +147,7 @@ class EventParsing:
             None,
             EventFormatError,
             False,
+            False,
         )
 
     def case_adm_cid(self):
@@ -155,6 +158,7 @@ class EventParsing:
             "Fire Alarm",
             "FA",
             None,
+            False,
             False,
         )
 
@@ -167,6 +171,7 @@ class EventParsing:
             "CL",
             None,
             False,
+            False,
         )
 
     def case_code_jc(self):
@@ -177,6 +182,7 @@ class EventParsing:
             "User code tamper canceled",
             "JC",
             None,
+            False,
             False,
         )
 
@@ -189,6 +195,7 @@ class EventParsing:
             "CL",
             None,
             True,
+            False,
         )
 
     def case_xdata_K(self):
@@ -200,6 +207,7 @@ class EventParsing:
             "RP",
             None,
             True,
+            False,
         )
 
     def case_xdata_X_and_Y(self):
@@ -211,6 +219,7 @@ class EventParsing:
             "PA",
             None,
             True,
+            False,
         )
 
     # TODO: add tests for different SIA versions (DC-04, DC09, DC09X)
@@ -223,6 +232,7 @@ class EventParsing:
             None,
             None,
             False,
+            True,
         )
 
     def case_encrypted_adm(self):
@@ -234,6 +244,7 @@ class EventParsing:
             None,
             None,
             False,
+            True,
         )
 
     def case_oh(self):
@@ -244,6 +255,7 @@ class EventParsing:
             "Automatic Test",
             "RP",
             None,
+            False,
             False,
         )
 
@@ -256,6 +268,7 @@ class EventParsing:
             "CL",
             None,
             False,
+            False,
         )
 
     def case_op(self):
@@ -266,6 +279,7 @@ class EventParsing:
             "Opening Report",
             "OP",
             None,
+            False,
             False,
         )
 
@@ -278,6 +292,7 @@ class EventParsing:
             None,
             None,
             False,
+            True,
         )
 
     def case_wa(self):
@@ -289,6 +304,7 @@ class EventParsing:
             "WA",
             None,
             False,
+            False,
         )
 
     def case_eventformaterror(self):
@@ -299,6 +315,7 @@ class EventParsing:
             None,
             None,
             EventFormatError,
+            False,
             False,
         )
 


### PR DESCRIPTION
Handling this situation
Emit different warning when event parsing failed on overall line or on content.