### PR TITLE
Quirks to support egardia / woonveilig alarm systems

### DIFF
--- a/src/pysiaalarm/account.py
+++ b/src/pysiaalarm/account.py
@@ -22,6 +22,7 @@ class SIAAccount:
     account_id: str
     key: Optional[str] = None
     allowed_timeband: Tuple[int, int] = (40, 20)
+    device_time_offset: int = 0
     key_b: Optional[bytes] = field(
         repr=False, default=None, metadata=config(exclude=Exclude.ALWAYS)  # type: ignore
     )

--- a/src/pysiaalarm/aio/client.py
+++ b/src/pysiaalarm/aio/client.py
@@ -26,6 +26,7 @@ class SIAClient(BaseSIAClient):
         accounts: List[SIAAccount],
         function: Callable[[SIAEvent], None],
         protocol: CommunicationsProtocol = CommunicationsProtocol.TCP,
+        binary_crc: bool = False,
     ):
         """Create the asynchronous SIA Client object.
 
@@ -45,7 +46,9 @@ class SIAClient(BaseSIAClient):
         self.dgprotocol: Any = None
         self.sia_server: Any = None
         if self.protocol == CommunicationsProtocol.TCP:
-            self.sia_server = SIAServer(self._accounts, self._func, self._counts)
+            self.sia_server = SIAServer(
+                self._accounts, self._func, self._counts, binary_crc
+            )
 
     async def __aenter__(self, **kwargs: Dict[str, Any]) -> SIAClient:
         """Start with as context manager."""

--- a/src/pysiaalarm/sync/server.py
+++ b/src/pysiaalarm/sync/server.py
@@ -25,6 +25,7 @@ class SIATCPServer(ThreadingTCPServer, BaseSIAServer):
         accounts: Dict[str, SIAAccount],
         func: Callable[[SIAEvent], None],
         counts: Counter,
+        binary_crc: bool = False,
     ):
         """Create a SIA TCP Server.
 
@@ -33,10 +34,11 @@ class SIATCPServer(ThreadingTCPServer, BaseSIAServer):
             accounts Dict[str, SIAAccount] -- accounts as dict with account_id as key, SIAAccount object as value.
             func Callable[[SIAEvent], None] -- Function called for each valid SIA event, that can be matched to a account.
             counts Counter -- counter kept by client to give insights in how many errorous events were discarded of each type.
+            binary_crc bool -- set to True if your system sends CRC in binary instead of hex
 
         """
         ThreadingTCPServer.__init__(self, server_address, SIATCPHandler)
-        BaseSIAServer.__init__(self, accounts, func, counts)
+        BaseSIAServer.__init__(self, accounts, func, counts, binary_crc)
 
 
 class SIAUDPServer(ThreadingUDPServer, BaseSIAServer):
@@ -51,6 +53,7 @@ class SIAUDPServer(ThreadingUDPServer, BaseSIAServer):
         accounts: Dict[str, SIAAccount],
         func: Callable[[SIAEvent], None],
         counts: Counter,
+        binary_crc: bool = False,
     ):
         """Create a SIA UDP Server.
 
@@ -59,6 +62,7 @@ class SIAUDPServer(ThreadingUDPServer, BaseSIAServer):
             accounts Dict[str, SIAAccount] -- accounts as dict with account_id as key, SIAAccount object as value.
             func Callable[[SIAEvent], None] -- Function called for each valid SIA event, that can be matched to a account.
             counts Counter -- counter kept by client to give insights in how many errorous events were discarded of each type.
+            binary_crc bool -- set to True if your system sends CRC in binary instead of hex
 
         """
         ThreadingUDPServer.__init__(self, server_address, SIAUDPHandler)


### PR DESCRIPTION
This alarm system has two specific quirks which pysiaalarm has to be aware of to work properly: it needs to support messages where the CRC is in binary instead of hexadecimal, and it needs to support devices which have timestamps in local time instead of UTC.

I've seen the "binary CRC" thing mentioned online for some other alarm systems, so it doesn't seem to be unique to this specific brand. I'm not sure if other systems exist that also use non-UTC time.

The commit messages should be pretty self-explanatory. Please check the message for  the binary CRC commit to see some comments about why a server setting is necessary, and how it could possibly be avoided with some changes to error handling. 

The binary CRC commit also has an unrelated correctness fix for responses, as noted in the commit message.