### PR TITLE
Osborne-Hoffman (aritech/interlogix) support

### DIFF
--- a/src/pysiaalarm/base_server.py
+++ b/src/pysiaalarm/base_server.py
@@ -56,6 +56,8 @@ class BaseSIAServer(ABC):
         self.log_and_count(COUNTER_EVENTS, line=line)
         try:
             event = SIAEvent.from_line(line, self.accounts)
+            if self.accounts and not event.sia_account and event.account:
+                event.sia_account = self.accounts.get(event.account, None)
         except NoAccountError as exc:
             self.log_and_count(COUNTER_ACCOUNT, line, exception=exc)
             return NAKEvent()

--- a/src/pysiaalarm/event.py
+++ b/src/pysiaalarm/event.py
@@ -160,6 +160,7 @@ class BaseEvent(ABC):
         encrypted = True if main_content["encrypted_flag"] else False
         acc = main_content["account"]
         sia_account = None
+
         if accounts and acc:
             sia_account = accounts.get(acc, None)
 
@@ -274,7 +275,7 @@ class SIAEvent(BaseEvent):
     @property
     def valid_message(self) -> bool:
         """Check the validity of the message by comparing the sent CRC with the calculated CRC."""
-        return self.msg_crc == self.calc_crc
+        return True  # self.msg_crc == self.calc_crc
 
     @property
     def valid_timestamp(self) -> bool:
@@ -305,6 +306,9 @@ class SIAEvent(BaseEvent):
         x_data = None
         if response_type is None:
             return b"\n\r"
+
+        return f'{response_type.value}\r'.encode("ascii")
+
         if not self.sia_account:
             return f'"{response_type.value}"'.encode("ascii")
         if (

--- a/src/pysiaalarm/sync/handler.py
+++ b/src/pysiaalarm/sync/handler.py
@@ -2,6 +2,8 @@
 
 import logging
 from socketserver import BaseRequestHandler
+from Crypto.Cipher import DES3
+from Crypto.Random import get_random_bytes
 
 from ..event import SIAEvent
 from ..utils import ResponseType
@@ -13,6 +15,8 @@ class BaseSIAHandler(BaseRequestHandler):
     """Base case for Request handling."""
 
     _received_data = "".encode()
+    _key = None
+    _cipher = None
 
     def handle_raw_line(self, raw: bytes) -> None:
         """Handle the line."""
@@ -40,23 +44,76 @@ class SIATCPHandler(BaseSIAHandler):
 
     def handle(self) -> None:
         """Overwritten method for the RequestHandler."""
+
+        if self._key is None:
+            self._key = DES3.adjust_key_parity(get_random_bytes(24))
+            self._cipher = DES3.new(self._key, mode=DES3.MODE_ECB)
+            scrambled_key = self.OsborneHoffmanScramble(self._key)
+            self.request.sendall(scrambled_key)
+
         while True and not self.server.shutdown_flag:  # type: ignore # pragma: no cover
             raw = self.request.recv(1024)
             if not raw:
                 break
+
             raw = bytearray(raw)
+
+            if self._key is not None:
+                raw = self._cipher.decrypt(raw)
+                padding_len = len(raw) - raw.rfind(b'\r') - 1
+                raw = raw[:-padding_len]
+
             self.handle_raw_line(raw)
 
     def respond(self, event: SIAEvent) -> None:
         """Respond to the event."""
         try:
-            self.request.sendall(event.create_response())
+            raw = event.create_response()
+            print('response', raw)
+
+            if self._key is not None:
+                block_size = 8
+                padding_len = block_size-len(raw)%block_size
+                padding = bytearray(chr(0)*(padding_len), 'ascii')
+                raw += padding
+                print(bytes(raw).hex())
+                raw = self._cipher.encrypt(raw)
+
+            self.request.sendall(raw)
         except Exception as exp:  # pragma: no cover
             _LOGGER.error(
                 "Exception caught while responding to event: %s, exception: %s",
                 event.create_response(),
                 exp,
             )
+
+    def OsborneHoffmanScramble(self, input):
+        key = bytearray(input)
+        key[3] ^= 0x05
+        key[4] ^= 0x23
+        key[9] ^= 0x29
+        key[1] ^= 0x2D
+        key[6] ^= 0x39
+        key[20] ^= 0x44
+        key[8] ^= 0x45
+        key[16] ^= 0x45
+        key[5] ^= 0x49
+        key[18] ^= 0x50
+        key[23] ^= 0x54
+        key[0] ^= 0x55
+        key[22] ^= 0x69
+        key[2] ^= 0x6A
+        key[15] ^= 0x88
+        key[19] ^= 0x8A
+        key[12] ^= 0x94
+        key[17] ^= 0xA3
+        key[7] ^= 0xA8
+        key[21] ^= 0xAA
+        key[14] ^= 0xB5
+        key[13] ^= 0xC2
+        key[10] ^= 0xD3
+        key[11] ^= 0xE9
+        return key
 
 
 class SIAUDPHandler(BaseSIAHandler):

--- a/src/pysiaalarm/utils/regexes.py
+++ b/src/pysiaalarm/utils/regexes.py
@@ -9,7 +9,7 @@ oh_regex = r"""
 ^S
 (?:R)(?P<receiver>(?<=R)(?:\d{4}))
 (?:L)(?P<line>(?<=L)(?:\d{4}))
-\s+(?P<account>\w{8})\s+
+\s+(?P<account>\w{8})\s|\x00+
 \[(?P<id>\w+)\]$
 """
 OH_MATCHER = re.compile(oh_regex, re.X)


### PR DESCRIPTION
For testing purposes I've hacked in Osborne-Hoffman (aritech/interlogix/honeywell) support into Home Assistant. OH+CID, OH+SIA or OH+XSIA it's called in documentation. As Honeywell is a major player, it would be great to get support in pysiaalarm. 

The Osborne-Hoffman protocol is a simple overlay that adds Triple DES support, this starts with the server sending a scrambled 192-bit DES key to the client. After the key is sent client communication can start whereby each packet is padded with zero's (not your standard padding scheme) and encrypted with 3DES ECB.

Here is an example of a SIA packet:
`01010053"SIA-DCS"0007R0075L0001[#001465|NRP000*'DECKERS'NM]7C9677F21948CC12|#001465`

There are a couple of SIA hacks made by Honeywell, this is not according the SIA specifications:
1. CRC is not calculated (it's statically set to 0101) and should not be checked
2. There is no account before "[" and the account is always filled in the content field (see fix in base_server.py)
3. There could be a whitespace in the ping packet (see fix in regexes.py)
4. Response is always in the following form `f'{response_type.value}\r'.encode("ascii")`

I somehow would like to store a setting that Osborne-Hoffman is enabled, and act accordingly. I should probably create a specific Osborne-Hoffman class. Right now I have no idea how to do add this nicely, so your suggestions are very welcome. 