### PR TITLE
Fix shutdown, optional qualifier, and default account

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	"image": "mcr.microsoft.com/devcontainers/python:3.14",
-	"appPort": 8126,
+	"runArgs": ["-p", "8126:8126"],
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ __pycache__/*
 .pydevproject
 .settings
 .idea
-.vscode
 tags
 
 # Package files

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Tests",
-            "type": "python",
-            "request": "test",
-            "console": "integratedTerminal",
-            "justMyCode": false,
-            "env": {"PYTEST_ADDOPTS": "--no-cov"}
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
         },
         {
             "name": "Python: AIO",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run_aio.py",
             "console": "integratedTerminal",
@@ -22,7 +21,7 @@
         },
         {
             "name": "Python: Thread",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "run.py",
             "console": "integratedTerminal",
@@ -30,7 +29,7 @@
         },
         {
             "name": "Python: Client AIO",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "test_client_aio.py",
             "console": "integratedTerminal",

--- a/src/pysiaalarm/account.py
+++ b/src/pysiaalarm/account.py
@@ -21,10 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 class SIAAccount:
     """Class for SIA Accounts."""
 
-    account_id: str
+    account_id: str = ""
     key: str | None = None
-    allowed_timeband: tuple[int, int] = (40, 20)
+    allowed_timeband: tuple[int, int] | None = (40, 20)
     device_timezone: tzinfo = pytz.utc
+    response_qualifier: str = ""
     key_b: bytes | None = field(
         repr=False,
         default=None,  # metadata=config(exclude=Exclude.ALWAYS)  # type: ignore
@@ -34,6 +35,7 @@ class SIAAccount:
         """Rewrite the key as bytes."""
         self.key_b = self.key.encode("utf-8") if self.key else None
         self.account_id = self.account_id.upper()
+        self.response_qualifier = self.response_qualifier.upper()
 
     @property
     def encrypted(self) -> bool:
@@ -59,7 +61,7 @@ class SIAAccount:
             InvalidAccountLengthError: If the account id does not have between 3 and 16 characters.
 
         """
-        if account_id is not None:  # pragma: no cover
+        if account_id:  # pragma: no cover
             try:
                 int(account_id, 16)
             except ValueError as exc:

--- a/src/pysiaalarm/aio/client.py
+++ b/src/pysiaalarm/aio/client.py
@@ -115,7 +115,7 @@ class SIAClientTCP(SIAClient):
     ) -> None:
         """Create the TCP SIA Client object."""
         super().__init__(host, port, accounts, function)
-        self.task: asyncio.Task | None = None
+        self.server: asyncio.Server | None = None
         self.sia_server: SIAServerTCP = SIAServerTCP(
             self._accounts, self._func, self._counts
         )
@@ -126,16 +126,19 @@ class SIAClientTCP(SIAClient):
         The rest of the arguments are passed directly to asyncio.start_server().
         """
         _LOGGER.debug("Starting SIA.")
-        coro = asyncio.start_server(
+        self.server = await asyncio.start_server(
             self.sia_server.handle_line, self._host, self._port, **kwargs
         )
-        self.task = asyncio.create_task(coro)
 
     async def async_stop(self) -> None:
         """Stop the asynchronous SIA TCP server."""
         _LOGGER.debug("Stopping SIA.")
+        if self.server is None:
+            return
         self.sia_server.shutdown_flag = True
-        await asyncio.gather(self.task)  # type: ignore
+        self.server.close()
+        await self.server.wait_closed()
+        self.server = None
 
 
 class SIAClientUDP(SIAClient):
@@ -153,6 +156,9 @@ class SIAClientUDP(SIAClient):
     ) -> None:
         """Create the UDP SIA Client object."""
         super().__init__(host, port, accounts, function)
+        self.sia_server: SIAServerUDP = SIAServerUDP(
+            self._accounts, self._func, self._counts
+        )
         self.transport: asyncio.BaseTransport | None = None
         self.dgprotocol: asyncio.BaseProtocol | None = None
 
@@ -164,7 +170,7 @@ class SIAClientUDP(SIAClient):
         _LOGGER.debug("Starting SIA.")
         loop = asyncio.get_running_loop()
         self.transport, self.dgprotocol = await loop.create_datagram_endpoint(
-            lambda: SIAServerUDP(self._accounts, self._func, self._counts),
+            lambda: self.sia_server,
             local_addr=(self._host, self._port),
             **kwargs,
         )
@@ -172,5 +178,8 @@ class SIAClientUDP(SIAClient):
     async def async_stop(self) -> None:
         """Stop the asynchronous SIA UDP server."""
         _LOGGER.debug("Stopping SIA.")
+        self.sia_server.shutdown_flag = True
         if self.transport is not None:
             self.transport.close()
+            self.transport = None
+            self.dgprotocol = None

--- a/tests/test_sia_package_cases.py
+++ b/tests/test_sia_package_cases.py
@@ -19,7 +19,7 @@ from pysiaalarm.const import (
     COUNTER_FORMAT,
     COUNTER_TIMESTAMP,
 )
-from tests.test_utils import ACCOUNT, KEY
+from tests.test_utils import ACCOUNT, KEY, crc_calc
 
 
 def encrypted_encrypted():
@@ -75,6 +75,23 @@ def msg_admcid():
 def msg_null():
     """Test class for Message type SIA-DCS."""
     return "NULL"
+
+
+def _build_adm_line(
+    event_qualifier,
+    event_type,
+    account=ACCOUNT,
+    partition="00",
+    ri="001",
+    seq="1234",
+):
+    """Build an ADM-CID line with a valid CRC/length."""
+    message = (
+        f'"ADM-CID"{seq}L0#{account}[#{account}|{event_qualifier}{event_type} {partition} {ri}]'
+    )
+    crc = crc_calc(message)
+    length = f"{len(message):04X}"
+    return f"{crc}{length}{message}"
 
 
 def fault_none():
@@ -169,6 +186,18 @@ class EventParsing:
             "4F39",
             "Closing Report",
             "CL",
+            None,
+            False,
+            False,
+        )
+
+    def case_adm_unknown_type(self):
+        """Test case ADM-CID format with unknown event type."""
+        return (
+            _build_adm_line("1", "999"),
+            ACCOUNT,
+            "Invalid Report",
+            "YN",
             None,
             False,
             False,


### PR DESCRIPTION
- Harden async TCP/UDP shutdown behavior and clean server lifecycle management; add extra logging for TCP event flow.
- Add `response_qualifier` to SIAAccount and include it in ACK/NAK/encrypted responses.
- Use a default account fallback when the exact account ID is missing.
- Improve ADM-CID parsing to return a default code for unknown types.
- Add tests covering response qualifier behavior, default account fallback, and shutdown handling for sync/async servers.
- Devcontainer/VS Code config tweaks for port mapping and debug configs.