### PR TITLE
Prevent double shutdown race

### DIFF
--- a/src/pysiaalarm/aio/client.py
+++ b/src/pysiaalarm/aio/client.py
@@ -133,7 +133,7 @@ class SIAClientTCP(SIAClient):
     async def async_stop(self) -> None:
         """Stop the asynchronous SIA TCP server."""
         _LOGGER.debug("Stopping SIA.")
-        if self.server is None:
+        if self.server is None or self.sia_server.shutdown_flag:
             return
         self.sia_server.shutdown_flag = True
         self.server.close()


### PR DESCRIPTION
It happens with Home Assistant integration because of the redundant call [here](https://github.com/home-assistant/core/blob/825da95550d50622ba32774adf6072d0de5fe4db/homeassistant/components/sia/hub.py#L68).